### PR TITLE
Nilpotence

### DIFF
--- a/algebra.cabal
+++ b/algebra.cabal
@@ -90,6 +90,7 @@ library
     Numeric.Coalgebra.Trigonometric.Class
     Numeric.Covector
     Numeric.Decidable.Associates
+    Numeric.Decidable.Nilpotent
     Numeric.Decidable.Units
     Numeric.Decidable.Zero
     Numeric.Dioid.Class

--- a/src/Numeric/Decidable/Nilpotent.hs
+++ b/src/Numeric/Decidable/Nilpotent.hs
@@ -9,7 +9,7 @@ import Numeric.Algebra
 import Numeric.Decidable.Zero
 import Prelude hiding (Num(..), Ord(..))
 
--- | An element `x` is nilpotent if there exists `n` s.t. `pow1p x n` is zero.
+-- | An element @x@ is nilpotent if there exists @n@ s.t. @pow1p x n@ is zero.
 class (Monoidal r, Multiplicative r) => DecidableNilpotent r where
     isNilpotent :: r -> Bool
 

--- a/src/Numeric/Decidable/Nilpotent.hs
+++ b/src/Numeric/Decidable/Nilpotent.hs
@@ -2,7 +2,7 @@
 
 module Numeric.Decidable.Nilpotent (DecidableNilpotent(..)) where
 
-import Data.Bits(Bits(), (.&.), zeroBits)
+import Data.Bits(Bits(..))
 import Data.Int(Int8,Int16,Int32,Int64)
 import Data.Word(Word8,Word16,Word32,Word64)
 import Numeric.Algebra

--- a/src/Numeric/Decidable/Nilpotent.hs
+++ b/src/Numeric/Decidable/Nilpotent.hs
@@ -55,7 +55,7 @@ instance (DecidableNilpotent a, DecidableNilpotent b, DecidableNilpotent c, Deci
     isNilpotent (a,b,c,d,e) = isNilpotent a && isNilpotent b && isNilpotent c && isNilpotent d && isNilpotent e
 
 unsignedBitsNilpotent :: (Bits r, Group r, Unital r) => r -> Bool
-unsignedBitsNilpotent b = (b /= one) && b .&. (b - one) == zeroBits
+unsignedBitsNilpotent b = (b /= one) && b .&. (b - one) == zero
 
 signedBitsNilpotent :: (Bits r, Group r, Order r, Bounded r, Unital r) => r -> Bool
 signedBitsNilpotent b | zero <~ b = unsignedBitsNilpotent b

--- a/src/Numeric/Decidable/Nilpotent.hs
+++ b/src/Numeric/Decidable/Nilpotent.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Numeric.Decidable.Nilpotent (DecidableNilpotent(..)) where
+
+import Data.Bits(Bits(), (.&.), zeroBits)
+import Data.Int(Int8,Int16,Int32,Int64)
+import Data.Word(Word8,Word16,Word32,Word64)
+import Numeric.Algebra
+import Numeric.Decidable.Zero
+import Prelude hiding (Num(..), Ord(..))
+
+-- | An element `x` is nilpotent if there exists `n` s.t. `pow1p x n` is zero.
+class (Monoidal r, Multiplicative r) => DecidableNilpotent r where
+    isNilpotent :: r -> Bool
+
+instance DecidableNilpotent () where
+    isNilpotent _ = True
+
+instance DecidableNilpotent Bool where
+    isNilpotent = isZero
+instance DecidableNilpotent Natural where
+    isNilpotent = isZero
+instance DecidableNilpotent Integer where
+    isNilpotent = isZero
+
+instance DecidableNilpotent Int where
+    isNilpotent = signedBitsNilpotent
+instance DecidableNilpotent Int8 where
+    isNilpotent = signedBitsNilpotent
+instance DecidableNilpotent Int16 where
+    isNilpotent = signedBitsNilpotent
+instance DecidableNilpotent Int32 where
+    isNilpotent = signedBitsNilpotent
+instance DecidableNilpotent Int64 where
+    isNilpotent = signedBitsNilpotent
+instance DecidableNilpotent Word8 where
+    isNilpotent = unsignedBitsNilpotent
+instance DecidableNilpotent Word16 where
+    isNilpotent = unsignedBitsNilpotent
+instance DecidableNilpotent Word32 where
+    isNilpotent = unsignedBitsNilpotent
+instance DecidableNilpotent Word64 where
+    isNilpotent = unsignedBitsNilpotent
+
+instance (DecidableNilpotent a, DecidableNilpotent b) => DecidableNilpotent (a,b) where
+    isNilpotent (a,b) = isNilpotent a && isNilpotent b
+
+instance (DecidableNilpotent a, DecidableNilpotent b, DecidableNilpotent c) => DecidableNilpotent (a,b,c) where
+    isNilpotent (a,b,c) = isNilpotent a && isNilpotent b && isNilpotent c
+
+instance (DecidableNilpotent a, DecidableNilpotent b, DecidableNilpotent c, DecidableNilpotent d) => DecidableNilpotent (a,b,c,d) where
+    isNilpotent (a,b,c,d) = isNilpotent a && isNilpotent b && isNilpotent c && isNilpotent d
+
+instance (DecidableNilpotent a, DecidableNilpotent b, DecidableNilpotent c, DecidableNilpotent d, DecidableNilpotent e) => DecidableNilpotent (a,b,c,d,e) where
+    isNilpotent (a,b,c,d,e) = isNilpotent a && isNilpotent b && isNilpotent c && isNilpotent d && isNilpotent e
+
+unsignedBitsNilpotent :: (Bits r, Group r, Unital r) => r -> Bool
+unsignedBitsNilpotent b = (b /= one) && b .&. (b - one) == zeroBits
+
+signedBitsNilpotent :: (Bits r, Group r, Order r, Bounded r, Unital r) => r -> Bool
+signedBitsNilpotent b | zero <~ b = unsignedBitsNilpotent b
+                      | otherwise = b == minBound ||
+                                    unsignedBitsNilpotent (negate b)
+


### PR DESCRIPTION
Add a DecidableNilpotent class.

I'm working on a fork of `polynomial` that uses `algebra` instead of `vector-space`. Having this class allows me to create a handy default definition for `DecidableUnit (Poly a)`: a polynomial over a commutative ring is a unit iff its constant term is a unit and all of the coefficients of its non-constant terms are nilpotent.