### PR TITLE
Make Data.Map a vector space.

### DIFF
--- a/algebra.cabal
+++ b/algebra.cabal
@@ -51,7 +51,7 @@ library
     mtl                     >= 2.0.1   && < 2.3,
     nats                    >= 0.1     && < 2,
     semigroups              >= 0.9     && < 1,
-    semigroupoids           >= 4       && < 5,
+    semigroupoids           >= 4       && < 6,
     transformers            >= 0.2     && < 0.5,
     tagged                  >= 0.4.2   && < 1,
     void                    >= 0.5.5.1 && < 1

--- a/src/Numeric/Additive/Class.hs
+++ b/src/Numeric/Additive/Class.hs
@@ -15,10 +15,12 @@ module Numeric.Additive.Class
 
 import Data.Int
 import Data.Word
+import Data.Map (Map)
+import qualified Data.Map
 import Data.Foldable hiding (concat)
 import Data.Semigroup.Foldable
 import Numeric.Natural
-import Prelude ((-),Bool(..),($),id,(>>=),fromIntegral,(*),otherwise,quot,maybe,error,even,Maybe(..),(==),(.),($!),Integer,(||),pred)
+import Prelude (Ord,(-),Bool(..),($),id,(>>=),fromIntegral,(*),otherwise,quot,maybe,error,even,Maybe(..),(==),(.),($!),Integer,(||),pred)
 import qualified Prelude
 import Data.List.NonEmpty (NonEmpty(..), fromList)
 
@@ -115,6 +117,9 @@ instance Additive () where
   sinnum1p _ _ = () 
   sumWith1 _ _ = ()
 
+instance (Ord k, Additive v) => Additive (Map k v) where
+  m1 + m2 = Data.Map.unionWith (+) m1 m2
+
 instance (Additive a, Additive b) => Additive (a,b) where
   (a,b) + (i,j) = (a + i, b + j)
   sinnum1p n (a,b) = (sinnum1p n a, sinnum1p n b)
@@ -196,6 +201,7 @@ instance (Abelian a, Abelian b) => Abelian (a,b)
 instance (Abelian a, Abelian b, Abelian c) => Abelian (a,b,c) 
 instance (Abelian a, Abelian b, Abelian c, Abelian d) => Abelian (a,b,c,d) 
 instance (Abelian a, Abelian b, Abelian c, Abelian d, Abelian e) => Abelian (a,b,c,d,e) 
+instance (Ord k,Additive v) => Abelian (Map k v) where
 
 -- | An additive semigroup with idempotent addition.
 --

--- a/src/Numeric/Additive/Group.hs
+++ b/src/Numeric/Additive/Group.hs
@@ -10,11 +10,12 @@ import Prelude hiding ((*), (+), (-), negate, subtract,zipWith)
 import qualified Prelude
 import Numeric.Additive.Class
 import Numeric.Algebra.Class
+import Data.Map (Map)
 
 infixl 6 - 
 infixl 7 `times`
 
-class (LeftModule Integer r, RightModule Integer r, Monoidal r) => Group r where
+class (Monoidal r) => Group r where
   (-)      :: r -> r -> r
   negate   :: r -> r
   subtract :: r -> r -> r
@@ -139,3 +140,6 @@ instance (Group a, Group b, Group c, Group d, Group e) => Group (a,b,c,d,e) wher
   subtract (a,b,c,d,e) (i,j,k,l,m) = (subtract a i, subtract b j, subtract c k, subtract d l, subtract e m)
   times n (a,b,c,d,e) = (times n a,times n b, times n c, times n d, times n e)
 
+
+instance (Ord k,Group v) => Group (Map k v) where
+  negate = fmap negate

--- a/src/Numeric/Algebra/Class.hs
+++ b/src/Numeric/Algebra/Class.hs
@@ -215,6 +215,15 @@ instance Semiring r => Algebra r IntSet where
        Nothing -> f ls s
        Just (r, rs) -> f ls s + go (IntSet.insert r ls) rs
 
+instance (Ord k,Additive v) => Monoidal (Map k v) where
+  zero = Map.empty
+
+instance (Ord k,LeftModule c v) => LeftModule c (Map k v) where
+  c .* m = fmap (c .*) m
+
+instance (Ord k,RightModule c v) => RightModule c (Map k v) where
+  m *. c = fmap (*. c) m
+
 instance (Semiring r, Monoidal r, Ord a, Partitionable b) => Algebra r (Map a b) -- where
 --  mult f xs = case minViewWithKey xs of
 --    Nothing -> zero 
@@ -371,8 +380,9 @@ instance Semiring r => LeftModule r () where
 instance LeftModule r m => LeftModule r (e -> m) where 
   (.*) m f e = m .* f e
 
-instance Additive m => LeftModule () m where 
-  _ .* a = a
+-- incoheRent
+-- instance  Additive m => LeftModule () m where 
+--   _ .* a = a
 
 instance (LeftModule r a, LeftModule r b) => LeftModule r (a, b) where
   n .* (a, b) = (n .* a, n .* b)
@@ -472,7 +482,7 @@ instance (LeftModule r m, RightModule r m) => Module r m
 -- | An additive monoid
 --
 -- > zero + a = a = a + zero
-class (LeftModule Natural m, RightModule Natural m) => Monoidal m where
+class (Additive m) => Monoidal m where
   zero :: m
 
   sinnum :: Natural -> m -> m

--- a/src/Numeric/Field/Fraction.hs
+++ b/src/Numeric/Field/Fraction.hs
@@ -98,16 +98,16 @@ instance Euclidean d => Monoidal (Fraction d) where
   zero = Fraction zero one
   {-# INLINE zero #-}
 instance Euclidean d => LeftModule Integer (Fraction d) where
-  n .* Fraction p r = (n .* p) % r
+  n .* Fraction p r = (times n p) % r
   {-# INLINE (.*) #-}
 instance Euclidean d => RightModule Integer (Fraction d) where
-  Fraction p r *. n = (p *. n) % r
+  Fraction p r *. n = (times n p) % r
   {-# INLINE (*.) #-}
 instance Euclidean d => LeftModule Natural (Fraction d) where
-  n .* Fraction p r = (n .* p) % r
+  n .* Fraction p r = (times n p) % r
   {-# INLINE (.*) #-}
 instance Euclidean d => RightModule Natural (Fraction d) where
-  Fraction p r *. n = (p *. n) % r
+  Fraction p r *. n = (times n p) % r
   {-# INLINE (*.) #-}
 instance Euclidean d => Additive (Fraction d) where
   Fraction p q + Fraction s t =


### PR DESCRIPTION

I tried to make Data.Map a vector space, but I found that the Left/RightModule Natural/Integer v superclass constraint of Monoidal/Group meant that I had to declare several incoherent instances.

Hence I have removed these constraints, as well as the LeftModule () a instance, which is also incoherent.

