### PR TITLE
Added workaround for GHC 8.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,98 @@
-language: haskell
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.24 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.4.2,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-7.6.3,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=head
+      compiler: ": #GHC head"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-head,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
+
+  allow_failures:
+    - env: CABALVER=1.24 GHCVER=head
+
+before_install:
+ - unset CC
+ - export HAPPYVER=1.19.5
+ - export ALEXVER=3.1.4
+ - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update
+ - "sed -i  's/^jobs:.*$/jobs: 2/' $HOME/.cabal/config"
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     if [ "$GHCVER" = "7.10.3" ]; then cabal install Cabal-1.22.4.0; fi;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests)
+ - cabal test
+ - cabal bench || true  # expected result: these will crash
+ - cabal sdist || true  # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+
 notifications:
   irc:
     channels:

--- a/algebra.cabal
+++ b/algebra.cabal
@@ -51,8 +51,8 @@ library
     mtl                     >= 2.0.1   && < 2.3,
     nats                    >= 0.1     && < 2,
     semigroups              >= 0.9     && < 1,
-    semigroupoids           >= 4       && < 5,
-    transformers            >= 0.2     && < 0.5,
+    semigroupoids           >= 4       && < 6,
+    transformers            >= 0.2     && < 0.6,
     tagged                  >= 0.4.2   && < 1,
     void                    >= 0.5.5.1 && < 1
 

--- a/algebra.cabal
+++ b/algebra.cabal
@@ -123,4 +123,6 @@ library
     Numeric.Semiring.Integral
     Numeric.Semiring.Involutive
 
-  ghc-options: -Wall
+  ghc-options: -Wall -fno-warn-unused-imports
+  if impl(ghc >= 8.0.1)
+     ghc-options: -Wno-redundant-constraints

--- a/src/Numeric/Decidable/Units.hs
+++ b/src/Numeric/Decidable/Units.hs
@@ -17,7 +17,7 @@ import Prelude hiding ((*))
 class Unital r => DecidableUnits r where
   recipUnit :: r -> Maybe r
 
-  isUnit :: DecidableUnits r => r -> Bool
+  isUnit :: r -> Bool
   isUnit = isJust . recipUnit
 
   (^?) :: Integral n => r -> n -> Maybe r

--- a/src/Numeric/Decidable/Units.hs
+++ b/src/Numeric/Decidable/Units.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstrainedClassMethods #-}
 module Numeric.Decidable.Units 
   ( DecidableUnits(..)
   , recipUnitIntegral

--- a/src/Numeric/Domain/Euclidean.hs
+++ b/src/Numeric/Domain/Euclidean.hs
@@ -11,9 +11,9 @@ import Numeric.Domain.Class
 import Numeric.Natural (Natural)
 import Numeric.Ring.Class
 import Prelude (Eq (..), Integer, Maybe (..), abs)
-import Prelude (fst, otherwise)
+import Prelude (fst, otherwise, fail)
 import Prelude (signum, snd, ($), (.))
-import qualified Prelude                 as P
+import qualified Prelude as P
 
 infixl 7 `quot`, `rem`
 infix  7 `divide`

--- a/src/Numeric/Quadrance/Class.hs
+++ b/src/Numeric/Quadrance/Class.hs
@@ -19,7 +19,7 @@ class Additive r => Quadrance r m where
 instance Quadrance () a where 
   quadrance _ = ()
 
-instance Monoidal r => Quadrance r () where
+instance (Additive r, Monoidal r) => Quadrance r () where
   quadrance _ = zero
 
 instance (Quadrance r a, Quadrance r b) => Quadrance r (a,b) where

--- a/stack-ghc710.yaml
+++ b/stack-ghc710.yaml
@@ -1,0 +1,4 @@
+resolver: lts-6.10
+
+packages:
+- '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: nightly-2016-08-06
+
+packages:
+- '.'


### PR DESCRIPTION
I weakened version constraints and added some (previously redundant) constraints to make `algebra` compiles with GHC 8.0.1.