### PR TITLE
Make *Module (Complex r) (Complex s) overlap

### DIFF
--- a/src/Numeric/Algebra/Complex.hs
+++ b/src/Numeric/Algebra/Complex.hs
@@ -184,8 +184,10 @@ instance (Commutative r, Ring r) => Rig (Complex r) where
 instance (Commutative r, Ring r) => Ring (Complex r) where
   fromInteger n = Complex (fromInteger n) zero
 
-instance (Commutative r, Rng r) => LeftModule (Complex r) (Complex r) where (.*) = (*)
-instance (Commutative r, Rng r) => RightModule (Complex r) (Complex r) where (*.) = (*)
+instance {-# OVERLAPPING #-} (Commutative r, Rng r) => LeftModule (Complex r) (Complex r) where
+  (.*) = (*)
+instance {-# OVERLAPPING #-} (Commutative r, Rng r) => RightModule (Complex r) (Complex r) where
+  (*.) = (*)
 
 instance (Commutative r, Rng r, InvolutiveMultiplication r) => InvolutiveMultiplication (Complex r) where
   adjoint (Complex a b) = Complex (adjoint a) (negate b)


### PR DESCRIPTION
This comes up more naturally in the resolution of
`Module (Complex r) (e -> Complex s)`.
Otherwise, one could argue that this instance is as bad as the putative
`class (LeftModule r r, RightModule r r, Additive r, Abelian r,
        Multiplicative r) => Semiring r`